### PR TITLE
connect to socket only once

### DIFF
--- a/lib/fake_web/ext/net_http.rb
+++ b/lib/fake_web/ext/net_http.rb
@@ -46,7 +46,10 @@ module Net  #:nodoc: all
         FakeWeb::Utility.produce_side_effects_of_net_http_request(request, body)
         FakeWeb.response_for(method, uri, &block)
       elsif FakeWeb.allow_net_connect?(uri)
-        connect_without_fakeweb
+        unless @already_connected ||= false
+          connect_without_fakeweb
+          @already_connected = true
+        end
         request_without_fakeweb(request, body, &block)
       else
         uri = FakeWeb::Utility.strip_default_port_from_uri(uri)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,7 +53,7 @@ module FakeWebTestHelper
       OpenSSL::SSL::SSLSocket.expects(:===).with(socket).returns(true).at_least_once
       OpenSSL::SSL::SSLSocket.expects(:new).with(socket, instance_of(OpenSSL::SSL::SSLContext)).returns(socket).at_least_once
       socket.stubs(:sync_close=).returns(true)
-      socket.expects(:connect).with().at_least_once
+      socket.expects(:connect).with().once
     else
       socket = mock("TCPSocket")
       Socket.expects(:===).with(socket).at_least_once.returns(true)


### PR DESCRIPTION
Hi Chris,

I was running into an issue with subsequent requests (without fakeweb) failing.  Making sure we only connect once to the socket fixed it.

Thanks for fakeweb.

/g
