### PR TITLE
:delay option for testing response timeouts

### DIFF
--- a/lib/fake_web/responder.rb
+++ b/lib/fake_web/responder.rb
@@ -35,6 +35,8 @@ module FakeWeb
       response.instance_variable_set(:@read, true)
       response.extend FakeWeb::Response
 
+      sleep(response_delay)
+
       optionally_raise(response)
 
       yield response if block_given?
@@ -116,6 +118,10 @@ module FakeWeb
       $stderr.puts "Deprecation warning: FakeWeb's :#{which} option has been renamed to :body."
       $stderr.puts "Just replace :#{which} with :body in your FakeWeb.register_uri calls."
       $stderr.puts "Called at #{caller[6]}"
+    end
+
+    def response_delay
+      options.has_key?(:delay) ? options[:delay] : 0
     end
 
   end

--- a/test/test_response_delay.rb
+++ b/test/test_response_delay.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class TestResponseDelay < Test::Unit::TestCase
+  # this doesn't work because it's all the same thread
+  #def test_response_delay_timeout
+    #FakeWeb.register_uri(:get, "http://example.com", :delay => 2)
+    #assert_raise TimeoutError do
+      #Net::HTTP.start("example.com") do |http|
+        #http.read_timeout = 1
+        #http.get("/")
+      #end
+    #end
+  #end
+
+  def test_response_delay_wait
+    FakeWeb.register_uri(:get, "http://example.com", :delay => 2, :body => fixture_path("test_example.txt"))
+    start_time = Time.now
+    response = Net::HTTP.start("example.com") do |http|
+      http.get("/")
+    end
+    end_time = Time.now
+    assert (end_time - start_time) > 2.0
+    assert_equal "test example content", response.body
+  end
+
+  def test_response_delay_timeout
+    FakeWeb.register_uri(:get, "http://example.com", :delay => 1, :body => fixture_path("test_example.txt"))
+    start_time = Time.now
+    response = Net::HTTP.start("example.com") do |http|
+      http.get("/")
+    end
+    end_time = Time.now
+    assert (end_time - start_time) < 3.0
+    assert_equal "test example content", response.body
+  end
+end


### PR DESCRIPTION
We have a very slow to respond web service we're calling and I added an option to set the read_timeout in the client to accommodate it. But I'd like to test that the read_timeout is being respected when we use FakeWeb to mock the web service. So I added a :delay option that makes FakeWeb wait the number of seconds requested using sleep().
