### PR TITLE
Request Block Support

### DIFF
--- a/lib/fake_web.rb
+++ b/lib/fake_web.rb
@@ -147,13 +147,17 @@ module FakeWeb
   # response more than once:
   #
   #   FakeWeb.register_uri(:get, "http://example.com", :set_cookie => ["name=value", "example=1"])
-  def self.register_uri(*args)
+  def self.register_uri(*args, &block)
     case args.length
     when 3
       Registry.instance.register_uri(*args)
     when 2
-      print_missing_http_method_deprecation_warning(*args)
-      Registry.instance.register_uri(:any, *args)
+      if block_given?
+        Registry.instance.register_uri(*args, &block)
+      else
+        print_missing_http_method_deprecation_warning(*args)
+        Registry.instance.register_uri(:any, *args)
+      end
     else
       raise ArgumentError.new("wrong number of arguments (#{args.length} for 3)")
     end
@@ -165,13 +169,13 @@ module FakeWeb
   # Returns the faked Net::HTTPResponse object associated with +method+ and +uri+.
   def self.response_for(*args, &block) #:nodoc: :yields: response
     case args.length
-    when 2
+    when 3, 2
       Registry.instance.response_for(*args, &block)
     when 1
       print_missing_http_method_deprecation_warning(*args)
       Registry.instance.response_for(:any, *args, &block)
     else
-      raise ArgumentError.new("wrong number of arguments (#{args.length} for 2)")
+      raise ArgumentError.new("wrong number of arguments (#{args.length} for 3)")
     end
   end
 

--- a/lib/fake_web/ext/net_http.rb
+++ b/lib/fake_web/ext/net_http.rb
@@ -44,7 +44,7 @@ module Net  #:nodoc: all
       if FakeWeb.registered_uri?(method, uri)
         @socket = Net::HTTP.socket_type.new
         FakeWeb::Utility.produce_side_effects_of_net_http_request(request, body)
-        FakeWeb.response_for(method, uri, &block)
+        FakeWeb.response_for(method, uri, request, &block)
       elsif FakeWeb.allow_net_connect?(uri)
         connect_without_fakeweb
         request_without_fakeweb(request, body, &block)

--- a/lib/fake_web/registry.rb
+++ b/lib/fake_web/registry.rb
@@ -2,7 +2,7 @@ module FakeWeb
   class Registry #:nodoc:
     include Singleton
 
-    attr_accessor :uri_map, :passthrough_uri_map
+    attr_accessor :uri_map, :passthrough_uri_map, :uri_block_map
 
     def initialize
       clean_registry
@@ -10,19 +10,37 @@ module FakeWeb
 
     def clean_registry
       self.uri_map = Hash.new { |hash, key| hash[key] = {} }
+      self.uri_block_map = Hash.new { |hash, key| hash[key] = {} }
     end
 
-    def register_uri(method, uri, options)
-      uri_map[normalize_uri(uri)][method] = [*[options]].flatten.collect do |option|
-        FakeWeb::Responder.new(method, uri, option, option[:times])
+    def register_uri(method, uri, options = nil, &block)
+      if block_given?
+        uri_block_map[normalize_uri(uri)][method] = block
+      else
+        if options.nil?
+          raise ArgumentError.new("wrong number of arguments (2 for 3)")
+        end
+
+        uri_map[normalize_uri(uri)][method] = [*[options]].flatten.collect do |option|
+          FakeWeb::Responder.new(method, uri, option, option[:times])
+        end
       end
     end
 
     def registered_uri?(method, uri)
-      !responders_for(method, uri).empty?
+      !block_responder_for(method, uri).nil? || !responders_for(method, uri).empty?
     end
 
-    def response_for(method, uri, &block)
+    def response_for(method, uri, request = nil, &block)
+      block_responder = block_responder_for(method, uri)
+      if block_responder
+        block_args = {:method => method, :uri => uri, :request => request}
+        option = block_responder.call(block_args)
+
+        responder = FakeWeb::Responder.new(method, uri, option, option[:times])
+        return responder.response(&block)
+      end
+
       responders = responders_for(method, uri)
       return nil if responders.empty?
 
@@ -55,13 +73,21 @@ module FakeWeb
     private
 
     def responders_for(method, uri)
+      responders_for_helper(uri_map, method, uri, [])
+    end
+
+    def block_responder_for(method, uri)
+      responders_for_helper(uri_block_map, method, uri, nil)
+    end
+
+    def responders_for_helper(map, method, uri, default)
       uri = normalize_uri(uri)
 
-      uri_map_matches(uri_map, method, uri, URI) ||
-      uri_map_matches(uri_map, :any,   uri, URI) ||
-      uri_map_matches(uri_map, method, uri, Regexp) ||
-      uri_map_matches(uri_map, :any,   uri, Regexp) ||
-      []
+      uri_map_matches(map, method, uri, URI) ||
+      uri_map_matches(map, :any,   uri, URI) ||
+      uri_map_matches(map, method, uri, Regexp) ||
+      uri_map_matches(map, :any,   uri, Regexp) ||
+      default
     end
 
     def uri_map_matches(map, method, uri, type_to_check = URI)

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -30,7 +30,7 @@ class TestFakeWeb < Test::Unit::TestCase
       FakeWeb.response_for
     end
     assert_raises ArgumentError do
-      FakeWeb.response_for(:get, "http://example.com", "/example")
+      FakeWeb.response_for(:get, "http://example.com", "/example", "/foo")
     end
   end
 


### PR DESCRIPTION
I've got preliminary support for the following syntax:

```
FakeWeb.register_uri(:post, "#{Utility.test_domain}/subscriptions.xml") do |request_args|
    make_subscription request_args
end
```

The block is executed each time a request comes in.  This allows a FakeWeb client to return responses based on the request body (or anything else).  The request_args looks like this:

```
{:request=>#<Net::HTTP::Post POST>,
 :uri=>
  "https://<host redacted>/subscriptions.xml",
 :method=>:post}
```

The block needs to return a hash (or array of hashes) that looks like the parameters that are missing from request_uri like so:
     {:status => 200, :body => "hi"}

Any of the options you can normally pass to request_uri after the http method and url are valid in the block return value.

This is a work in progress and has no tests yet.  I'm looking for feedback at this point.
