### PR TITLE
a method to help with testing/debugging

### DIFF
--- a/lib/fake_web/registry.rb
+++ b/lib/fake_web/registry.rb
@@ -8,6 +8,13 @@ module FakeWeb
       clean_registry
     end
 
+    def uri_map
+      def @uri_map.inspect
+        self.keys.map(&:to_s)
+      end
+      @uri_map
+    end
+
     def clean_registry
       self.uri_map = Hash.new { |hash, key| hash[key] = {} }
     end

--- a/test/test_registry.rb
+++ b/test/test_registry.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class TestUtility < Test::Unit::TestCase
+
+  def test_uri_map_inspect_returns_an_array_of_a_known_uri
+    FakeWeb.register_uri(:get,"http://google.com",:status => 200,:body => {})
+    assert_equal ["http://google.com/"], FakeWeb::Registry.instance.uri_map.inspect
+  end
+
+  def test_uri_map_inspect_returns_an_array_of_known_uris
+    FakeWeb.register_uri(:get,"http://google.com",:status => 200,:body => {})
+    FakeWeb.register_uri(:get,"http://heroku.com",:status => 200,:body => {})
+    assert_equal ["http://heroku.com/","http://google.com/"], FakeWeb::Registry.instance.uri_map.inspect
+  end
+
+end


### PR DESCRIPTION
Hey! 

I have found myself checking FakeWeb::Registry.uri_map a lot lately. Most of the time when I do this I am looking to make sure that I am stubbing the correct uris. This is necessary when I have helper methods generate stubs dynamically....

Anyways, I did a closure over uri_map. Not sure this is the most idiomatic way to handle this, but it led to some nice syntax. 

Fakeweb::Registry.uri_map.inspect #=> [uri,uri]

Also, I am thinking of adding a counter the registry that show how many time the stubbed uri has been hit. Any thoughts on this? 
