### PR TITLE
Allow StringIO as input to monkey-patched BufferedIO class. 

### DIFF
--- a/lib/fake_web/ext/net_http.rb
+++ b/lib/fake_web/ext/net_http.rb
@@ -11,7 +11,7 @@ module Net  #:nodoc: all
       @debug_output = debug_output
 
       @io = case io
-      when Socket, OpenSSL::SSL::SSLSocket, IO
+      when Socket, OpenSSL::SSL::SSLSocket, StringIO, IO
         io
       when String
         if !io.include?("\0") && File.exists?(io) && !File.directory?(io)


### PR DESCRIPTION
Note that this makes FakeWeb compatible with the Artifice gem.
