### PR TITLE
It seems that Fakeweb doesn't like Mechanize agent's read_timeout= method

### DIFF
--- a/lib/fake_web/stub_socket.rb
+++ b/lib/fake_web/stub_socket.rb
@@ -10,6 +10,9 @@ module FakeWeb
 
     def readuntil(*args)
     end
+    
+    def read_timeout=(*args)
+    end
 
   end
 end


### PR DESCRIPTION
It seems that Fakeweb doesn't like Mechanize agent's read_timeout= method (http://stackoverflow.com/questions/7137467/ruby-fakeweb-error-if-a-mechanize-agents-read-timeout-is-called)
