### PR TITLE
Remove trailing dots from links as RubyForge doesnt parse it out.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,12 +15,12 @@ gems lying around, remove them: <tt>gem uninstall FakeWeb</tt>
 
 == Help and discussion
 
-RDocs for the current release are available at http://fakeweb.rubyforge.org.
+RDocs for the current release are available at http://fakeweb.rubyforge.org
 
 There's a mailing list for questions and discussion at
-http://groups.google.com/group/fakeweb-users.
+http://groups.google.com/group/fakeweb-users
 
-The main source repository is http://github.com/chrisk/fakeweb.
+The main source repository is http://github.com/chrisk/fakeweb
 
 == Examples
 


### PR DESCRIPTION
From http://fakeweb.rubyforge.org/
Links
http://fakeweb.rubyforge.org. => works ok!
https://groups.google.com/forum/#!forum/fakeweb-users. => There is no group named “fakeweb-users.”.
https://github.com/chrisk/fakeweb. => 404 not found
