### PR TITLE
Return nil when the body is stubbed as '' or nil.

### DIFF
--- a/lib/fake_web/responder.rb
+++ b/lib/fake_web/responder.rb
@@ -52,7 +52,8 @@ module FakeWeb
 
     def body
       body = options[:body]
-      return "" if body.nil?
+      return nil if body.to_s == ''
+
       body = body.to_s if defined?(Pathname) && body.is_a?(Pathname)
 
       if !body.include?("\0") && File.exists?(body) && !File.directory?(body)

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -357,7 +357,13 @@ class TestFakeWeb < Test::Unit::TestCase
   def test_specifying_nil_for_body
     FakeWeb.register_uri(:head, "http://example.com", :body => nil)
     response = Net::HTTP.start("example.com") { |query| query.head("/") }
-    assert_equal "", response.body
+    assert_equal nil, response.body
+  end
+
+  def test_specifying_empty_string_for_body
+    FakeWeb.register_uri(:head, "http://example.com", :body => '')
+    response = Net::HTTP.start("example.com") { |query| query.head("/") }
+    assert_equal nil, response.body
   end
 
   def test_real_http_request


### PR DESCRIPTION
When a real Net::HTTP request is made and receives an
empty-body response (such as a 204 No Content), then the
response body is nil.

This gist demonstrates the behavior:
https://gist.github.com/2918173
