### PR TITLE
Created a method to unregister an URI

### DIFF
--- a/lib/fake_web.rb
+++ b/lib/fake_web.rb
@@ -159,6 +159,16 @@ module FakeWeb
     end
   end
 
+  def self.unregister_uri(*args)
+    case args.length
+    when 2
+      Registry.instance.unregister_uri(*args)
+    else
+      raise ArgumentError.new("wrong number of arguments (#{args.length} for 2)")
+    end
+  end
+
+
   # call-seq:
   #   FakeWeb.response_for(method, uri)
   #

--- a/lib/fake_web/registry.rb
+++ b/lib/fake_web/registry.rb
@@ -18,6 +18,10 @@ module FakeWeb
       end
     end
 
+    def unregister_uri(method, uri)
+      uri_map[normalize_uri(uri)][method] = {}
+    end
+
     def registered_uri?(method, uri)
       !responders_for(method, uri).empty?
     end

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -111,6 +111,32 @@ class TestFakeWeb < Test::Unit::TestCase
     assert !FakeWeb.registered_uri?(:get, "http://example.com")
   end
 
+  def test_unregister_uri
+    FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
+    assert FakeWeb.registered_uri?(:get, "http://example.com")
+    FakeWeb.unregister_uri(:get, "http://example.com")
+    assert !FakeWeb.registered_uri?(:get, "http://example.com")
+  end
+
+  def test_unregister_uri_affects_only_one_uri
+    FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
+    FakeWeb.register_uri(:get, "http://other.example.com", :body => "registered")
+    assert FakeWeb.registered_uri?(:get, "http://example.com")
+    assert FakeWeb.registered_uri?(:get, "http://other.example.com")
+    FakeWeb.unregister_uri(:get, "http://example.com")
+    assert !FakeWeb.registered_uri?(:get, "http://example.com")
+    assert FakeWeb.registered_uri?(:get, "http://other.example.com")
+  end
+
+  def test_unregistered_uri_can_be_registered_again
+    FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
+    assert FakeWeb.registered_uri?(:get, "http://example.com")
+    FakeWeb.unregister_uri(:get, "http://example.com")
+    assert !FakeWeb.registered_uri?(:get, "http://example.com")
+    FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
+    assert FakeWeb.registered_uri?(:get, "http://example.com")
+  end
+
   def test_clean_registry_affects_net_http_requests
     FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
     response = Net::HTTP.start("example.com") { |query| query.get("/") }


### PR DESCRIPTION
I needed to unregister URIs in one project that I'm using fakeweb and I was unable find this feature, so I implemented it for you.  
