### PR TITLE
Update test suite to be compatible with Ruby 2

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,12 +57,18 @@ module FakeWebTestHelper
       OpenSSL::SSL::SSLSocket.expects(:new).with(socket, instance_of(OpenSSL::SSL::SSLContext)).returns(socket).at_least_once
       socket.stubs(:sync_close=).returns(true)
       socket.expects(:connect).with().at_least_once
+      socket.expects(:session).with().at_least_once if RUBY_VERSION >= "2.0.0"
     else
       socket = mock("TCPSocket")
       Socket.expects(:===).with(socket).at_least_once.returns(true)
     end
 
-    TCPSocket.expects(:open).with(options[:host], options[:port]).returns(socket).at_least_once
+    if RUBY_VERSION >= "2.0.0"
+      TCPSocket.expects(:open).with(options[:host], options[:port], nil, nil).returns(socket).at_least_once
+    else
+      TCPSocket.expects(:open).with(options[:host], options[:port]).returns(socket).at_least_once
+    end
+
     socket.stubs(:closed?).returns(false)
     socket.stubs(:close).returns(true)
 


### PR DESCRIPTION
`net/http` in Ruby 2 changed a bit and it now calls `TCPSocket.open` with more options as well as `session()` for a socket over SSL.

This patch simply adjust the mocking in `test_helper.rb` for Ruby 2 leaving previous versions untouched. Please accept.
