### PR TITLE
Add #read_timeout and #continue_timeout to match Net::HTTP API

### DIFF
--- a/lib/fake_web/stub_socket.rb
+++ b/lib/fake_web/stub_socket.rb
@@ -1,6 +1,8 @@
 module FakeWeb
   class StubSocket #:nodoc:
 
+    attr_accessor :read_timeout, :continue_timeout
+
     def initialize(*args)
     end
 


### PR DESCRIPTION
Net::HTTPSession objects support #read_timeout and #continue_timeout setters and getters.  When using fakeweb via VCR, code using these attributes raise errors (NoMethodError: undefined method).  

Adding these attributes resolve the issue.
