### PR TITLE
Clean out an specific uri from registry

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,6 +131,10 @@ registry and remove all registered URIs:
 
   FakeWeb.clean_registry
 
+If you want clean out an specific uri, you can remove it from registry:
+
+  FakeWeb.clean_uri(:get, "http://example.com")
+
 === Blocking all real requests
 
 When you're using FakeWeb to replace _all_ of your requests, it's useful to

--- a/lib/fake_web.rb
+++ b/lib/fake_web.rb
@@ -21,6 +21,11 @@ module FakeWeb
     Registry.instance.clean_registry
   end
 
+  # Remove added uri from registry.
+  def self.clean_uri(method, uri)
+    Registry.instance.clean_uri(method, uri)
+  end
+
   # Enables or disables real HTTP connections for requests that don't match
   # registered URIs.
   #

--- a/lib/fake_web/registry.rb
+++ b/lib/fake_web/registry.rb
@@ -12,6 +12,12 @@ module FakeWeb
       self.uri_map = Hash.new { |hash, key| hash[key] = {} }
     end
 
+    def clean_uri(method, uri)
+      n_uri = normalize_uri(uri)
+      self.uri_map[n_uri].delete(method)
+      self.uri_map.delete(n_uri) unless self.uri_map[n_uri].size > 0
+    end
+
     def register_uri(method, uri, options)
       uri_map[normalize_uri(uri)][method] = [*[options]].flatten.collect do |option|
         FakeWeb::Responder.new(method, uri, option, option[:times])

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -111,6 +111,16 @@ class TestFakeWeb < Test::Unit::TestCase
     assert !FakeWeb.registered_uri?(:get, "http://example.com")
   end
 
+  def test_clean_uri_affects_registered_uri
+    FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
+    FakeWeb.register_uri(:post, "http://example.com", :body => "registered")
+    assert FakeWeb.registered_uri?(:get, "http://example.com")
+    assert FakeWeb.registered_uri?(:post, "http://example.com")
+    FakeWeb.clean_uri(:get, "http://example.com")
+    assert !FakeWeb.registered_uri?(:get, "http://example.com")
+    assert FakeWeb.registered_uri?(:post, "http://example.com")
+  end
+
   def test_clean_registry_affects_net_http_requests
     FakeWeb.register_uri(:get, "http://example.com", :body => "registered")
     response = Net::HTTP.start("example.com") { |query| query.get("/") }


### PR DESCRIPTION
I have added new method for clean an specific uri from registry.
Thus offering users the ability to have a test where a specific uri is not faked.
