### PR TITLE
Fix reconnect on keep alive timeout when allowing all connections.

### DIFF
--- a/lib/fake_web.rb
+++ b/lib/fake_web.rb
@@ -68,6 +68,12 @@ module FakeWeb
     end
   end
 
+  # Returns +true+ if requests to all URIs are passed through to Net::HTTP
+  # for normal processing (the default), otherwise, returns +false+.
+  def self.allow_all_connections?
+    Registry.instance.passthrough_uri_map.empty? && Registry.instance.uri_map.empty? && @allow_all_connections
+  end
+
   # This exception is raised if you set <tt>FakeWeb.allow_net_connect =
   # false</tt> and subsequently try to make a request to a URI you haven't
   # stubbed.

--- a/lib/fake_web/ext/net_http.rb
+++ b/lib/fake_web/ext/net_http.rb
@@ -45,7 +45,7 @@ module Net  #:nodoc: all
         FakeWeb::Utility.produce_side_effects_of_net_http_request(request, body)
         FakeWeb.response_for(method, uri, &block)
       elsif FakeWeb.allow_net_connect?(uri)
-        connect_without_fakeweb
+        connect_without_fakeweb unless FakeWeb.allow_all_connections?
         request_without_fakeweb(request, body, &block)
       else
         uri = FakeWeb::Utility.strip_default_port_from_uri(uri)
@@ -62,7 +62,7 @@ module Net  #:nodoc: all
         FakeWeb::Utility.puts_warning_for_net_http_replacement_libs_if_needed
         @@alredy_checked_for_net_http_replacement_libs = true
       end
-      nil
+      FakeWeb.allow_all_connections? ? connect_without_fakeweb : nil
     end
     alias_method :connect_without_fakeweb, :connect
     alias_method :connect, :connect_with_fakeweb

--- a/test/test_allow_all_connections.rb
+++ b/test/test_allow_all_connections.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class TestAllowAllConnections < Test::Unit::TestCase
+  def test_net_http_can_reconnect_on_keep_alive_timeout_when_allow_all_connections
+    FakeWeb.allow_net_connect = true
+    uri = URI.parse("http://images.apple.com/main/rss/hotnews/hotnews.rss")
+    req = Net::HTTP::Get.new(uri)
+    Net::HTTP.new(uri.host, uri.port).start do |http|
+      http.keep_alive_timeout = 0
+      http.request(req)
+      http.request(req)
+    end
+  end if RUBY_VERSION >= "2.0.0"
+
+  def test_allow_all_connections_returns_true_without_registered_uris_or_passthroughs
+    FakeWeb.allow_net_connect = true
+    assert_equal true, FakeWeb.allow_all_connections?
+  end
+
+  def test_allow_all_connections_returns_false_with_passthrough
+    FakeWeb.allow_net_connect = "http://example.com"
+    assert_equal false, FakeWeb.allow_all_connections?
+  end
+
+  def test_allow_all_connections_returns_false_without_allow_net_connect
+    FakeWeb.allow_net_connect = false
+    assert_equal false, FakeWeb.allow_all_connections?
+  end
+
+  def test_allow_all_connections_returns_false_registered_uris
+    FakeWeb.allow_net_connect = true
+    FakeWeb.register_uri(:get, "http://example.com", :status => [404, "Not Found"])
+    assert_equal false, FakeWeb.allow_all_connections?
+  end
+end


### PR DESCRIPTION
## Problem

Ruby 2.0 added a keep_alive_timeout variable to Net::HTTP for persistent.  If keep_alive_timeout seconds has passed between requests, then Net::HTTP will close the socket and call connect.  However, fakeweb replaces the `connect` method to have it do nothing (delaying it until request is called), so the socket is closed without reconnecting on a keep_alive_timeout.

The following script will result in a `closed stream (IOError)` exception being raised, but will run without exceptions after removing `require 'fakeweb'`.

```
require 'net/http'
require 'fakeweb'

uri = URI("http://www.google.com/")
req = Net::HTTP::Get.new(uri)

Net::HTTP.new(uri.host, uri.port).start do |http|
  http.request(req)
  sleep 2  # default keep_alive_timeout
  http.request(req)
end
```

fakeweb sets `FakeWeb.allow_net_connect = true` on initialization.  In this state, we should avoid changing the behaviour of Net::HTTP so that it works in cases that fakeweb wasn't designed for.
## Solution

Add `FakeWeb.allow_all_connections?` which returns true if fakeweb isn't intercepting any any requests (i.e. `FakeWeb.allow_net_connect = true`).  In this state, the Net::HTTP monkey patch returns the behaviour of the `connect` and `request` method by just calling the real methods.
## Remaining Problem

fakeweb will still have this problem for persistent http connections when passthrough uri's are registered, but I didn't want to complicate this pull request by trying to solve this use case.  I wanted to start by making sure fakeweb isn't disruptive when it is required but isn't being used, or when it is disabled for certain tests.

Update: created pull #44 to address this problem.
