### PR TITLE
Make exception support more generic

### DIFF
--- a/lib/fake_web/responder.rb
+++ b/lib/fake_web/responder.rb
@@ -102,8 +102,8 @@ module FakeWeb
     def optionally_raise(response)
       return unless options.has_key?(:exception)
 
-      case options[:exception].to_s
-      when "Net::HTTPError", "OpenURI::HTTPError"
+      case options[:exception].instance_method(:initialize).arity
+      when 2
         raise options[:exception].new('Exception from FakeWeb', response)
       else
         raise options[:exception].new('Exception from FakeWeb')

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -444,6 +444,17 @@ class TestFakeWeb < Test::Unit::TestCase
     end
   end
 
+  def test_mock_post_that_raises_other_http_errors
+    [Net::HTTPRetriableError, Net::HTTPServerException, Net::HTTPFatalError, OpenURI::HTTPError].each do |error_class|
+      FakeWeb.register_uri(:post, 'http://mock/raising_exception.txt', :exception => error_class)
+      assert_raises(error_class) do
+        Net::HTTP.start('mock') do |query|
+          query.post('/raising_exception.txt', '')
+        end
+      end
+    end
+  end
+
   def test_raising_an_exception_that_requires_an_argument_to_instantiate
     FakeWeb.register_uri(:get, "http://example.com/timeout.txt", :exception => Timeout::Error)
     assert_raises(Timeout::Error) do


### PR DESCRIPTION
Support Net::HTTPFatalError and others that require an additional
argument.
