### PR TITLE
Fix rbx on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx
+  - rbx-2
 before_install: gem install bundler --conservative --version '~> 1.3' --no-prerelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ rvm:
   - jruby-head
   - rbx-2
 before_install: gem install bundler --conservative --version '~> 1.3' --no-prerelease
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/fakeweb.gemspec
+++ b/fakeweb.gemspec
@@ -63,6 +63,9 @@ Gem::Specification.new do |s|
     s.add_development_dependency "json",              ["~> 1.7"]
   end
 
+  if RUBY_VERSION >= "2.0"
+    s.add_development_dependency "test-unit"
+  end
 
   if RUBY_PLATFORM == "java"
     s.add_development_dependency "jruby-openssl", ["~> 0.8"]


### PR DESCRIPTION
Per
http://docs.travis-ci.com/user/languages/ruby/#Choosing-Ruby-versions-and-implementations-to-test-against

"When using Rubinius, there's currently an issue with selecting the
correct version in RVM in our build environment, but only when
specifying rbx as your version. As a workaround, specify rbx-2 instead."

Also, explicitly require test-unit to fix test suite on ruby-head.
