### PR TITLE
Fix tests by expecting TypeError for Ruby 2.2

### DIFF
--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -35,7 +35,9 @@ class TestFakeWeb < Test::Unit::TestCase
   end
 
   def test_register_uri_without_domain_name
-    assert_raises URI::InvalidURIError do
+    # Ruby 2.1 and lower raises URI::InvalidURIError
+    # Ruby 2.2 and higher raises TypeError
+    assert_raises URI::InvalidURIError, TypeError do
       FakeWeb.register_uri(:get, 'test_example2.txt', fixture_path("test_example.txt"))
     end
   end


### PR DESCRIPTION
This fixes failed builds on master:

https://travis-ci.org/chrisk/fakeweb/jobs/28254294

Note: it won't show success until https://github.com/chrisk/fakeweb/pull/48 is merged.
