### PR TITLE
Miscellaneous testing fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,13 @@ require 'rubygems'
 require 'rake'
 
 task :print_header do
-  version_string = `rvm current`.strip
-  version_string = RUBY_DESCRIPTION if !$?.success?
-  puts "\n# Starting tests using \e[1m#{version_string}\e[0m\n\n"
+  if system("which rvm > /dev/null")
+    version_string = `rvm current`.strip
+    version_string = RUBY_DESCRIPTION if !$?.success?
+    puts "\n# Starting tests using \e[1m#{version_string}\e[0m\n\n"
+  else
+    puts "\n# RVM not found. Using default Ruby (#{RUBY_DESCRIPTION})"
+  end
 end
 
 

--- a/fakeweb.gemspec
+++ b/fakeweb.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
     # Otherwise, prefer up-to-date dev tools
     s.add_development_dependency "mocha", ["~> 0.14"] + broken_mocha_spec
     s.add_development_dependency "rake",  ["~> 10.0"]
+    s.add_development_dependency "test-unit", ["~> 3.2.3"]
 
     # ZenTest (autotest) wants at least RubyGems 1.8, which is 1.8.7+
     # only, as is RDoc, the main dependency of sdoc.

--- a/test/helpers/start_simplecov.rb
+++ b/test/helpers/start_simplecov.rb
@@ -24,7 +24,7 @@ module FakeWebTestHelper
         formatters << Console
         formatters << HTMLFormatter if html_report_requested?
       end
-      MultiFormatter[*formatters]
+      MultiFormatter.new(formatters)
     end
 
     def this_process_responsible_for_coverage_reporting?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,7 +119,13 @@ module FakeWebTestHelper
       OpenSSL::SSL::SSLSocket.expects(:===).with(socket).returns(true).at_least_once
       OpenSSL::SSL::SSLSocket.expects(:new).with(socket, instance_of(OpenSSL::SSL::SSLContext)).returns(socket).at_least_once
       socket.stubs(:sync_close=).returns(true)
-      socket.expects(:connect).with().at_least_once
+
+      if RUBY_VERSION >= "2.3.0"
+        socket.expects(:connect_nonblock).with(any_parameters).at_least_once
+      else
+        socket.expects(:connect).with().at_least_once
+      end
+
       if RUBY_VERSION >= "2.0.0" && RUBY_PLATFORM != "java"
         socket.expects(:session).with().at_least_once
       end


### PR DESCRIPTION
**Changes**
- Removes the RVM requirement to run Rake tasks
- Adds `test-unit` to development dependencies (no longer included in recent versions of Ruby)
- Removes a SimpleCov deprecation warning
- Ensures `allow_net_connect` is correctly reset after tests to avoid cascading failures
- Fixes stubs for recent versions of Ruby