### PR TITLE
Since Ruby 2.2, it is safe to call #close on closed socket.

### DIFF
--- a/lib/fake_web/stub_socket.rb
+++ b/lib/fake_web/stub_socket.rb
@@ -12,6 +12,9 @@ module FakeWeb
       @closed ||= true
     end
 
+    def close
+    end
+
     def readuntil(*args)
     end
   end


### PR DESCRIPTION
The #closed? checks were removed by r56865, so this method is needed by Ruby 2.4.