### PR TITLE
Some fixes for ruby 2.4.1 compatibility

### DIFF
--- a/fakeweb.gemspec
+++ b/fakeweb.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |s|
     # warning when the Ruby 1.9 stdlib is the only available backend.
     # See https://github.com/intridea/multi_json/commit/e7438e7ba2.
     s.add_development_dependency "json",              ["~> 1.7"]
+    s.add_development_dependency "test-unit",         ["~> 3.2"]
   end
 
 

--- a/fakeweb.gemspec
+++ b/fakeweb.gemspec
@@ -68,4 +68,13 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM == "java"
     s.add_development_dependency "jruby-openssl", ["~> 0.8"]
   end
+
+  s.post_install_message = %q{
+DEPRECATION MESSAGE:
+You use a temporary fork of original https://github.com/chrisk/fakeweb
+Please switch back to the original repository of fakeweb!
+
+# Gemfile
+gem "fakeweb", github: "chrisk/fakeweb", branch: "master"
+}
 end

--- a/lib/fake_web/ext/net_http.rb
+++ b/lib/fake_web/ext/net_http.rb
@@ -5,8 +5,8 @@ require 'stringio'
 module Net  #:nodoc: all
 
   class BufferedIO
-    def initialize_with_fakeweb(*args)
-      initialize_without_fakeweb(*args)
+    def initialize_with_fakeweb(*args, **opts)
+      initialize_without_fakeweb(*args, **opts)
 
       case @io
       when Socket, OpenSSL::SSL::SSLSocket, StringIO, IO

--- a/lib/fake_web/stub_socket.rb
+++ b/lib/fake_web/stub_socket.rb
@@ -8,6 +8,10 @@ module FakeWeb
     def initialize(*args)
     end
 
+    def close
+      @closed = true
+    end
+
     def closed?
       @closed ||= true
     end

--- a/test/helpers/start_simplecov.rb
+++ b/test/helpers/start_simplecov.rb
@@ -24,7 +24,7 @@ module FakeWebTestHelper
         formatters << Console
         formatters << HTMLFormatter if html_report_requested?
       end
-      MultiFormatter[*formatters]
+      MultiFormatter.new formatters
     end
 
     def this_process_responsible_for_coverage_reporting?

--- a/test/test_fake_web.rb
+++ b/test/test_fake_web.rb
@@ -34,10 +34,15 @@ class TestFakeWeb < Test::Unit::TestCase
     end
   end
 
-  def test_register_uri_without_domain_name
+  def test_register_uri_with_invalid_symbol
     assert_raises URI::InvalidURIError do
-      FakeWeb.register_uri(:get, 'test_example2.txt', fixture_path("test_example.txt"))
+      FakeWeb.register_uri(:get, 'test_example2 txt', :body => 'foo')
     end
+  end
+
+  def test_register_uri_without_domain_name
+    FakeWeb.register_uri(:get, 'test_example2.txt', :body => 'foo')
+    assert FakeWeb.registered_uri?(:get, 'http://test_example2.txt/')
   end
 
   def test_register_uri_with_port_and_check_with_port

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,7 +119,11 @@ module FakeWebTestHelper
       OpenSSL::SSL::SSLSocket.expects(:===).with(socket).returns(true).at_least_once
       OpenSSL::SSL::SSLSocket.expects(:new).with(socket, instance_of(OpenSSL::SSL::SSLContext)).returns(socket).at_least_once
       socket.stubs(:sync_close=).returns(true)
-      socket.expects(:connect).with().at_least_once
+
+      if RUBY_VERSION <= "2.4.0"
+        socket.expects(:connect).with().at_least_once
+      end
+
       if RUBY_VERSION >= "2.0.0" && RUBY_PLATFORM != "java"
         socket.expects(:session).with().at_least_once
       end
@@ -141,6 +145,7 @@ module FakeWebTestHelper
 
     socket.stubs(:closed?).returns(false)
     socket.stubs(:close).returns(true)
+    socket.stubs(:connect_nonblock).returns(true)
 
     # Request/response handling
     request_parts = ["#{options[:method]} #{options[:path]} HTTP/1.1", "Host: #{options[:host]}"]


### PR DESCRIPTION
Hi there! 

On ruby-2.4.1 it raises an error:

```
     NoMethodError:
       undefined method `<<' for {:read_timeout=>60, :continue_timeout=>nil, :debug_output=>nil}:Hash
       Did you mean?  <
     # .rvm/gems/ruby-2.4.1/gems/fakeweb-1.3.0/lib/fake_web/ext/net_http.rb:50:in `request_with_fakeweb'
```

I made some little fixes in order to use the gem with ruby-2.4.1. May be someone would find it helpful.

```
# Gemfile

group :test do
  gem "fakeweb", github: "SamMolokanov/fakeweb", branch: "ruby-2-4-1-support"
end
```

#57 